### PR TITLE
Adopt future go yaml line wrapping behavior

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,12 +6,16 @@ import (
 	"log"
 	"os"
 
+	goyaml "gopkg.in/yaml.v2"
 	"github.com/ghodss/yaml"
 )
 
 func main() {
 	yamltojson := flag.Bool("yamltojson", false, "Convert yaml to json instead of the default json to yaml.")
 	flag.Parse()
+
+	// Don't wrap long lines
+	goyaml.FutureLineWrap()
 
 	inBytes, err := ioutil.ReadAll(os.Stdin)
 	if err != nil {


### PR DESCRIPTION
Closes #7

In v3, go yaml will not wrap lines by default: adopt this now to avoid churn later and return to the previous default used in v2.3.0 which was un-defaulted in v2.4.0 back to pre v2.3.0 behavior.